### PR TITLE
Fix broken footer link

### DIFF
--- a/client/js/pages/landing/footer.js
+++ b/client/js/pages/landing/footer.js
@@ -24,7 +24,7 @@ module.exports = function (state, prev, send) {
           <h4 class="footer-heading horizontal-rule-footer">Connect</h4>
           <ul class="footer-nav-list">
             <li><a href="https://twitter.com/dat_project">Twitter</a></li>
-            <li><a href="https://github.com/datproject/dat">GitHub</a></li>
+            <li><a href="https://github.com/datproject">GitHub</a></li>
             <li>
               <a href="https://tinyletter.com/datdata" target="_blank">Newsletter </a>
             </li>

--- a/client/js/pages/landing/footer.js
+++ b/client/js/pages/landing/footer.js
@@ -24,7 +24,7 @@ module.exports = function (state, prev, send) {
           <h4 class="footer-heading horizontal-rule-footer">Connect</h4>
           <ul class="footer-nav-list">
             <li><a href="https://twitter.com/dat_project">Twitter</a></li>
-            <li><a href="https://github.com/datproject/datproject">GitHub</a></li>
+            <li><a href="https://github.com/datproject/dat">GitHub</a></li>
             <li>
               <a href="https://tinyletter.com/datdata" target="_blank">Newsletter </a>
             </li>


### PR DESCRIPTION
datproject/datproject is not a valid github repository, and therefore will 404
when visited. This commit points the Github footer link to datproject/dat
instead, which seems like a logical place to me.