### PR TITLE
Refresh server metadata

### DIFF
--- a/client/js/models/read-only-archive.js
+++ b/client/js/models/read-only-archive.js
@@ -32,6 +32,7 @@ module.exports = {
       if (!state.key) return done()
       http({url: `/metadata/${state.key}`, method: 'GET', json: true}, function (err, resp, json) {
         if (err) return send('archive:update', {error: {message: err.message}}, done)
+        if (!err) json.error = null
         send('archive:update', json, done)
       })
     },

--- a/client/js/models/read-only-archive.js
+++ b/client/js/models/read-only-archive.js
@@ -32,7 +32,8 @@ module.exports = {
       if (!state.key) return done()
       http({url: `/metadata/${state.key}`, method: 'GET', json: true}, function (err, resp, json) {
         if (err) return send('archive:update', {error: {message: err.message}}, done)
-        if (!err) json.error = null
+        if (json.error) return send('archive:update', json, done)
+        if (json.entries) json.error = null
         send('archive:update', json, done)
       })
     },

--- a/client/js/models/read-only-archive.js
+++ b/client/js/models/read-only-archive.js
@@ -22,7 +22,9 @@ module.exports = {
   },
   subscriptions: {
     metadata: function (send, done) {
-      send('archive:getMetadata', {}, done)
+      setInterval(function () {
+        send('archive:getMetadata', {}, done)
+      }, 3000)
     }
   },
   effects: {

--- a/client/js/pages/archive/index.js
+++ b/client/js/pages/archive/index.js
@@ -11,7 +11,7 @@ const hyperdriveStats = require('../../elements/hyperdrive-stats')
 
 var ARCHIVE_ERRORS = {
   'Invalid key': 'No dat here.',
-  'timed out': 'No sources found.',
+  'timed out': 'Looking for sources...',
   'Username not found.': 'That user does not exist.',
   'Dat with that name not found.': 'That user does not have a dat with that name.'
 }
@@ -21,7 +21,11 @@ const archivePage = (state, prev, send) => {
     var cleaned = ARCHIVE_ERRORS[state.archive.error.message]
     if (cleaned) {
       var props = {
-        header: cleaned
+        header: cleaned,
+      }
+      if (cleaned === 'Looking for sources...') {
+        props.icon = 'loader'
+        props.body = 'Is the address correct? This could take a while.'
       }
       return html`
       <div>

--- a/client/js/pages/archive/index.js
+++ b/client/js/pages/archive/index.js
@@ -21,7 +21,7 @@ const archivePage = (state, prev, send) => {
     var cleaned = ARCHIVE_ERRORS[state.archive.error.message]
     if (cleaned) {
       var props = {
-        header: cleaned,
+        header: cleaned
       }
       if (cleaned === 'Looking for sources...') {
         props.icon = 'loader'

--- a/server/dats.js
+++ b/server/dats.js
@@ -26,14 +26,12 @@ Dats.prototype.get = function (key, cb) {
   var self = this
   key = encoding.toStr(key)
   var buf = encoding.toBuf(key)
-  if (self.archives[key]) return cb(null, self.archives[key])
   self.archiver.add(buf, {content: true}, function (err) {
     if (err) return cb(err)
     self.archiver.get(buf, function (err, metadata, content) {
       if (err) return cb(err)
       if (content) {
         var archive = self.drive.createArchive(buf, {metadata: metadata, content: content})
-        self.archives[key] = archive
         return cb(null, archive)
       }
     })

--- a/server/dats.js
+++ b/server/dats.js
@@ -84,6 +84,7 @@ Dats.prototype.metadata = function (archive, cb) {
             dat.metadata = metadata ? JSON.parse(metadata.toString()) : undefined
           } catch (e) {
           }
+          dat.size = archive.content.bytes
           return cb(null, dat)
         })
       })

--- a/server/router.js
+++ b/server/router.js
@@ -97,9 +97,20 @@ module.exports = function (opts, db) {
   })
 
   router.get('/metadata/:archiveKey', function (req, res) {
+    var cancelled = false
+    var timeout = setTimeout(function () {
+      if (cancelled) return
+      cancelled = true
+      return res.status(200).json({error: {message: 'timed out'}})
+    }, 3000)
+
+    console.log('getting key')
     dats.get(req.params.archiveKey, function (err, archive) {
       if (err) return onerror(err, res)
       dats.metadata(archive, function (err, info) {
+        clearTimeout(timeout)
+        if (cancelled) return
+        cancelled = true
         if (err) return onerror(err, res)
         return res.status(200).json(info)
       })

--- a/server/router.js
+++ b/server/router.js
@@ -1,4 +1,5 @@
 const fs = require('fs')
+const xtend = require('xtend')
 const path = require('path')
 const compression = require('compression')
 const bodyParser = require('body-parser')
@@ -20,7 +21,7 @@ module.exports = function (opts, db) {
 
   const log = bole(__filename)
   const dats = opts.dats || Dats(opts.archiver)
-  const TIMEOUT = 5000
+  const TIMEOUT = 1000
 
   var router = express()
   router.use(compression())
@@ -160,14 +161,12 @@ module.exports = function (opts, db) {
     dats.get(state.archive.key, function (err, archive) {
       if (err) return onerror(err)
       log.info('got archive', archive.key.toString('hex'))
-      dats.entries(archive, function (err, entries) {
+      dats.metadata(archive, function (err, info) {
         clearTimeout(timeout)
         if (cancelled) return
         cancelled = true
         if (err) state.archive.error = {message: err.message}
-        state.archive.size = archive.content.bytes
-        state.archive.peers = archive.content.peers.length
-        state.archive.entries = entries
+        state.archive = xtend(state.archive, info)
         cb(state)
       })
     })


### PR DESCRIPTION
fixes #323 

* Lowers the rendering timeout to 1s for archives, and replaces the 'no sources found' page with a loading page.
* Will ping for new updates to the archive info from the server every 3s (TODO: make this SSE/ws)
* **BONUS** Updates the filelist and metadata dynamically as its changed, too