### PR TITLE
small style fixes

### DIFF
--- a/client/js/components/header.js
+++ b/client/js/components/header.js
@@ -9,7 +9,7 @@ var headerStyles = css`
  :host {
    height: var(--site-header-height);
    background-color: var(--color-white);
-   border-bottom: 1px solid var(--color-neutral-04);
+   border-bottom: 1px solid var(--color-neutral-10);
  }
 `
 

--- a/client/js/pages/archive/index.js
+++ b/client/js/pages/archive/index.js
@@ -71,11 +71,27 @@ const archivePage = (state, prev, send) => {
           <div id="author" class="author-name">${description}</div>
           ${error(state.archive.error)}
           <div class="dat-details">
-            <div id="permissions" class="dat-detail">
-              ${permissions({owner: owner})}
-            </div>
-            <div id="hyperdrive-size" class="dat-detail"><p class="size">${size ? prettyBytes(size) : ''}</p></div>
-            <div id='peers' class='dat-detail'>${peers} Source${peers > 1 || peers === 0 ? 's' : ''}</div>
+            ${permissions
+              ? html`
+                <div id="permissions" class="dat-detail">
+                  ${permissions({owner: owner})}
+                </div>
+                `
+              : ''}
+            ${size
+              ? html`
+                <div id="hyperdrive-size" class="dat-detail">
+                  ${prettyBytes(size)}
+                </div>
+                `
+              : ''}
+            ${peers
+              ? html`
+                <div id="peers" class="dat-detail">
+                  ${peers} Source${peers > 1 || peers === 0 ? 's' : ''}
+                </div>
+                `
+              : ''}
           </div>
         </div>
       </div>

--- a/client/scss/imports/_dat-header.scss
+++ b/client/scss/imports/_dat-header.scss
@@ -45,9 +45,6 @@
 .share-link {
   display: flex;
   font-size: 1.375rem;
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .dat-details {


### PR DESCRIPTION
better contrast, remove unnecessary truncation, only show permissions/size/peers when data exists