### PR TITLE
fix link to dat paper

### DIFF
--- a/client/pages/home.js
+++ b/client/pages/home.js
@@ -87,7 +87,7 @@ module.exports = function (state, emit) {
             target="_blank"
             rel="noopener noreferrer"
             class="link"
-            href="https://github.com/datproject/docs/raw/master/papers/dat-paper.pdf"
+            href="/paper"
             >Dat paper</a>.
         `,
         'sections': [

--- a/client/pages/home.js
+++ b/client/pages/home.js
@@ -83,7 +83,12 @@ module.exports = function (state, emit) {
         'title': 'Why use Dat Protocol?',
         'subtitle': `
           We set out to improve access to public data and created a new protocol along the way.
-          Learn more in the <a class="link" href="/paper">Dat paper</a>.
+          Learn more in the <a
+            target="_blank"
+            rel="noopener noreferrer"
+            class="link"
+            href="https://github.com/datproject/docs/raw/master/papers/dat-paper.pdf"
+            >Dat paper</a>.
         `,
         'sections': [
           {


### PR DESCRIPTION
Got a DM that the link to the paper was broken — think this might be a good stop-gap solution until we figure out what's the root cause of the `/paper` link not working. Thanks!